### PR TITLE
use computed value when setting x,y etc attributes

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -1824,6 +1824,7 @@
             (this.desc = $("desc"))[appendChild](doc.createTextNode("Created with Rapha\xebl"));
             c[appendChild](this.desc);
             c[appendChild](this.defs = $("defs"));
+            return this;
         };
         paperproto.remove = function () {
             this.canvas.parentNode && this.canvas.parentNode.removeChild(this.canvas);


### PR DESCRIPTION
(specifically x,y,cx,cy,rx,ry,width,height)
Fixes `shape.attr('x','20').translate(10,0)`
and even `shape.attr('x','1cm').translate(10,0)`
