### PR TITLE
fix `.stop()` not cancelling callbacks of multiple animations

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -1824,6 +1824,7 @@
             (this.desc = $("desc"))[appendChild](doc.createTextNode("Created with Rapha\xebl"));
             c[appendChild](this.desc);
             c[appendChild](this.defs = $("defs"));
+            return this;
         };
         paperproto.remove = function () {
             this.canvas.parentNode && this.canvas.parentNode.removeChild(this.canvas);


### PR DESCRIPTION
If `.animate()` is called multiple times, `._ac` will be overwritten by the callback of the last animation, and when `.stop()` is called only the timeout for the callback of that last animation will be cleared.

Seeing as `timeouts` is only ever accessed to clear all of them in `.stop()`, the timeout id of animation callbacks are now pushed onto `timeouts` rather than assigned to `._ac`.
