### PR TITLE
The difference in real and expected animated parameters value in the final callback.

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -3483,6 +3483,7 @@
                 t: {x: 0, y: 0}
             });
             R.is(callback, "function") && (element._ac = setTimeout(function () {
+                element.attr(to);
                 callback.call(element);
             }, ms));
             animationElements[length] == 1 && setTimeout(animation);


### PR DESCRIPTION
Hi Dmitry!

I've noticed a couple of subtle bugs related to the following behaviour of Raphael. When an animation is finished, final callback is called and in this callback I relied on the fact that object is already in the state which has been specified by animated parameters. But due to some rounding errors the value of parameters slightly differs from expected ones. 
Example code:

```
circle.animate({cx: 100}, callback);
```

In callback I expect 'cx' to be 100, but it's actual value is something like 100.00000102312365663.

This might seem as a minor error, but the problem is I use these values in collision engine and the errors tend to increase with time, becoming more and more significant.

At first I have manually adjusted the values in my own code, but then I decided that this behaviour is a natural one and added the patch to the library. I'm not sure if it's the only place where this be changed but with this patch, the things are working as expected. I have seen the similar code in the of "var animation = ..." code:

```
(t.x || t.y) && that.translate(-t.x, -t.y);
to.scale && (to.scale += E);
that.attr(to); 
```

But perhaps it isn't called before the final callback is called.

Please let me know if I got something wrong.

Thanks!
