### PR TITLE
2.0

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -1435,9 +1435,13 @@
         getContainer = function (x, y, w, h) {
             var container;
             if (R.is(x, string) || R.is(x, "object")) {
-                container = h == null ? g.doc.getElementById(x) : x;
-                if (container == null) {
-                    return;
+                if (x.tagName) {
+                    container = x;
+                } else {
+                    container = h == null ? g.doc.getElementById(x) : x;
+                    if (container == null) {
+                        return;
+                    }
                 }
                 if (container.tagName) {
                     if (y == null) {


### PR DESCRIPTION
Fixed a bug in the main function that prevented an HTMLElement from being passed as a container. It was previously only working if the `x` argument on `getContainer` was an element ID (when passing 3 arguments.)
