### PR TITLE
2.0

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -2329,7 +2329,7 @@
                 var texts = Str(params.text).split("\n"),
                     tspans = [],
                     tspan;
-                for (var i = 0, ii = texts.length; i < ii; i++) if (texts[i]) {
+                for (var i = 0, ii = texts.length; i < ii; i++) {
                     tspan = $("tspan");
                     i && $(tspan, {dy: fontSize * leading, x: a.x});
                     tspan.appendChild(g.doc.createTextNode(texts[i]));


### PR DESCRIPTION
Just a simple change -- I had empty text elements I needed to transform, so I needed to change one spot.

Also, wanted to say I love the arrow heads -- the documentation doesn't mention "arrow-start" as well as "arrow-end" -- and I saw they both work, which is wonderful, but firefox 3.6 seemed really to struggle to animate the paths, though, once I turned this on?

Thanks for all your work.
