### PR TITLE
Updated to include firefox renderfix bug workaround

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -3054,8 +3054,11 @@
            Special thanks to Mariusz Nowak (http://www.medikoo.com/) for this method.
         \*/
         paperproto.renderfix = function () {
-            var cnvs = this.canvas,
-                s = cnvs.style,
+            // Certain builds of firefox do not support this method on the root element
+            if (!((cnvs = this.canvas).getScreenCTM()))
+                return;
+
+            var s = cnvs.style,
                 pos = cnvs.getScreenCTM(),
                 left = -pos.e % 1,
                 top = -pos.f % 1;


### PR DESCRIPTION
Firefox has a wonky getScreenCTM() method in some versions that return null instead of a matrix so this patch just avoids attempting to apply the renderfix if it can't.
