### PR TITLE
Fixes an edge case when calling toFront on a set in IE

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -2381,7 +2381,7 @@
         };
         elproto.toFront = function () {
             !this.removed && this.Group.parentNode[appendChild](this.Group);
-            this.paper.top != this && tofront(this, this.paper);
+            this.paper && this.paper.top != this && tofront(this, this.paper);
             return this;
         };
         elproto.toBack = function () {


### PR DESCRIPTION
When calling toFront in some cases on a set "this.paper" is undefined in IE, and an exception is thrown because this.paper.top can not be called
