### PR TITLE
Fixes an edge case when calling toFront on a set in IE (2.0 branch)

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -3741,7 +3741,7 @@
         };
         elproto.toFront = function () {
             !this.removed && this.node.parentNode.appendChild(this.node);
-            this.paper.top != this && tofront(this, this.paper);
+            this.paper && this.paper.top != this && tofront(this, this.paper);
             return this;
         };
         elproto.toBack = function () {


### PR DESCRIPTION
When calling toFront in some cases on a set "this.paper" is undefined in IE, and an exception is thrown because this.paper.top can not be called

There is a pull request for master branch as well. It was happening in both branches.
