### PR TITLE
clip-rect attribute bugfix

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -4606,8 +4606,7 @@ window.Raphael.vml && function (R) {
                 rect[2] = +rect[2] + (+rect[0]);
                 rect[3] = +rect[3] + (+rect[1]);
                 var div = node.clipRect || R._g.doc.createElement("div"),
-                    dstyle = div.style,
-                    group = node.parentNode;
+                    dstyle = div.style;
                 dstyle.clip = R.format("rect({1}px {2}px {3}px {0}px)", rect);
                 if (!node.clipRect) {
                     dstyle.position = "absolute";
@@ -4615,8 +4614,8 @@ window.Raphael.vml && function (R) {
                     dstyle.left = 0;
                     dstyle.width = o.paper.width + "px";
                     dstyle.height = o.paper.height + "px";
-                    group.parentNode.insertBefore(div, group);
-                    div.appendChild(group);
+                    node.parentNode.insertBefore(div, node);
+                    div.appendChild(node);
                     node.clipRect = div;
                 }
             }


### PR DESCRIPTION
Fixed clip-rect attribute moving canvas to absolute position in VML mode (IE7 and IE8).

This should fix [issue 389](https://github.com/DmitryBaranovskiy/raphael/issues/389).

--
Pavel Chuchuva
