### PR TITLE
Updating documentation for removal of namespaced plugins in 2.0

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -346,9 +346,10 @@
      **
      * You can add your own method to the canvas. For example if you want to draw a pie chart,
      * you can create your own pie chart function and ship it as a Raphaël plugin. To do this
-     * you need to extend the `Raphael.fn` object. Please note that you can create your own namespaces
-     * inside the `fn` object — methods will be run in the context of canvas anyway. You should alter
-     * the `fn` object before a Raphaël instance is created, otherwise it will take no effect.
+     * you need to extend the `Raphael.fn` object. You should modify the `fn` object before a
+     * Raphaël instance is created, otherwise it will take no effect. Please note that the
+     * ability for namespaced plugins was removed in Raphael 2.0. It is up to the plugin to
+     * ensure any namespacing ensures proper context.
      > Usage
      | Raphael.fn.arrow = function (x1, y1, x2, y2, size) {
      |     return this.path( ... );


### PR DESCRIPTION
Updating documentation so that the removal of plugin namespacing in 2.0 is stated.
