### PR TITLE
Spelling/Typo in Reference

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -511,7 +511,7 @@ c.node.onclick<span class="s"> = </span><b>function</b> () {
 }
 </code></pre>
 </div><div class="Element-remove-section"><h3 id="Element.remove" class="dr-method"><i class="dr-trixie">&#160;</i>Element.remove()<a href="#Element.remove" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 868 in the source" href="https://github.com/DmitryBaranovskiy/raphael/blob/master/raphael.svg.js#L868">&#x27ad;</a></h3>
-<div class="extra" id="Element.remove-extra"></div></div><div class="dr-method"><p>Removes element form the paper.
+<div class="extra" id="Element.remove-extra"></div></div><div class="dr-method"><p>Removes element from the paper.
 </p>
 </div><div class="Element-removeData-section"><h3 id="Element.removeData" class="dr-method"><i class="dr-trixie">&#160;</i>Element.removeData([key])<a href="#Element.removeData" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 2611 in the source" href="https://github.com/DmitryBaranovskiy/raphael/blob/master/raphael.core.js#L2611">&#x27ad;</a></h3>
 <div class="extra" id="Element.removeData-extra"></div></div><div class="dr-method"><p>Removes value associated with an element by given key.


### PR DESCRIPTION
Small typo I noticed when looking up something in the documentation, love the library by the way, used it in two project now, it's great.
