### PR TITLE
Fix to make IE9 display tooltips when setting the title attribute on an element.

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -3720,6 +3720,10 @@ window.Raphael.svg && function (R) {
                         break;
                     case "href":
                     case "title":
+                        var t = $('title');
+                        t.nodeValue = value;
+                        node.appendChild(t);
+                        // fall through...
                     case "target":
                         var pn = node.parentNode;
                         if (pn.tagName.toLowerCase() != "a") {


### PR DESCRIPTION
https://groups.google.com/group/raphaeljs/browse_thread/thread/9e56db1abb92e1cc
