### PR TITLE
Fix to make IE9 display tooltips when setting the title attribute on an element.

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -3721,7 +3721,7 @@ window.Raphael.svg && function (R) {
                     case "href":
                     case "title":
                         var t = $('title');
-                        t.nodeValue = value;
+                        t.appendChild(R._g.doc.createTextNode(value));
                         node.appendChild(t);
                         // fall through...
                     case "target":


### PR DESCRIPTION
https://groups.google.com/group/raphaeljs/browse_thread/thread/9e56db1abb92e1cc

If we add a title element as a child of the element we want to apply a title attr to, then tooltips in IE9 work.
