### PR TITLE
Fixed transform animation bug

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -4345,6 +4345,7 @@
         item = this.items[--i].animate(anim);
         while (i--) {
             this.items[i] && !this.items[i].removed && this.items[i].animateWith(item, anim, anim);
+            (this.items[i] && !this.items[i].removed) || len--;
         }
         return this;
     };


### PR DESCRIPTION
Looks like a small typo, caused transform animations of already rotated objects to move in completely the wrong direction.
