### PR TITLE
quick fix for arrow-end issues #471 and #506

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -3632,8 +3632,10 @@ window.Raphael.svg && function (R) {
                 o._.arrows = {};
             }
             if (type != "none") {
-                var pathId = "raphael-marker-" + type,
-                    markerId = "raphael-marker-" + se + type + w + h;
+                // makes markerCounter obsolete, no refactoring done yet:
+                var randSuffix = Math.random().toString(36).substring(7),
+                    pathId = "raphael-marker-" + type,
+                    markerId = "raphael-marker-" + se + type + w + h + randSuffix;
                 if (!R._g.doc.getElementById(pathId)) {
                     p.defs.appendChild($($("path"), {
                         "stroke-linecap": "round",


### PR DESCRIPTION
This is a quick and dirty fix for the following arrow-end issues:

https://github.com/DmitryBaranovskiy/raphael/issues/506
https://github.com/DmitryBaranovskiy/raphael/issues/471

We simply make the `markerId` always unique. This seems to work in chrome and FF. 

A lot of re-factoring needs to be done to remove the housekeeping for marker re-use (like `markerCounter`), but that's not something I'll undertake.
