### PR TITLE
Added caching of fill patterns by url.

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -225,6 +225,7 @@
             x: nu,
             y: nu
         },
+        patternCache = R._patternCache = {},
         whitespace = /[\x09\x0a\x0b\x0c\x0d\x20\xa0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029]/g,
         commaSpaces = /[\x09\x0a\x0b\x0c\x0d\x20\xa0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029]*,[\x09\x0a\x0b\x0c\x0d\x20\xa0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000\u2028\u2029]*/,
         hsrg = {hs: 1, rg: 1},

--- a/raphael.svg.js
+++ b/raphael.svg.js
@@ -466,15 +466,23 @@ window.Raphael.svg && function (R) {
                     case "fill":
                         var isURL = Str(value).match(R._ISURL);
                         if (isURL) {
+                            var url = isURL[1],
+                                uuid = R._patternCache[url]
+                                ;
+                            if (uuid) {
+                                $(node, {fill: "url(#" + uuid + ")"});
+                                break;
+                            }
                             el = $("pattern");
                             var ig = $("image");
                             el.id = R.createUUID();
+                            R._patternCache[url] = el.id;
                             $(el, {x: 0, y: 0, patternUnits: "userSpaceOnUse", height: 1, width: 1});
-                            $(ig, {x: 0, y: 0, "xlink:href": isURL[1]});
+                            $(ig, {x: 0, y: 0, "xlink:href": url});
                             el.appendChild(ig);
 
                             (function (el) {
-                                R._preload(isURL[1], function () {
+                                R._preload(url, function () {
                                     var w = this.offsetWidth,
                                         h = this.offsetHeight;
                                     $(el, {width: w, height: h});


### PR DESCRIPTION
I noticed in Firefox that dyamically changing the pattern fill for a path
(e.g. fill: "url(image.jpg)") seemed slow, and caused the image to flash as
its fill was removed and re-added.  Investigating I noticed the pattern was
re-created with a new UUID each time the fill was changed, even when the URL
was the same. Caching the patterns speeds things up greatly.
