### PR TITLE
Resolves IE7 issue with innerHTML on elements other than div. Workaround...

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -5175,7 +5175,11 @@ window.Raphael.vml && function (R) {
             a["font-style"] && (s.fontStyle = a["font-style"]);
             fontSize = toFloat(a["font-size"] || fontSize && fontSize[0]) || 10;
             s.fontSize = fontSize * m + "px";
-            res.textpath.string && (span.innerHTML = Str(res.textpath.string).replace(/</g, "&#60;").replace(/&/g, "&#38;").replace(/\n/g, "<br>"));
+            /*Resolve IE7 issue with innerHTML*/
+            var newdiv = document.createElement("div");
+            res.textpath.string && (newdiv.innerHTML = Str(res.textpath.string).replace(/</g, "&#60;").replace(/&/g, "&#38;").replace(/\n/g, "<br>"));
+            span.appendChild(newdiv);
+            /*end of resolution*/
             var brect = span.getBoundingClientRect();
             res.W = a.w = (brect.right - brect.left) / m;
             res.H = a.h = (brect.bottom - brect.top) / m;


### PR DESCRIPTION
... is to create a div element, change its innerHTML and then append the div to span.
