### PR TITLE
Fixed error with assuming last element always has implicit offset of 100...

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -2073,7 +2073,7 @@
                         }
                     }
                     if (!end) {
-                        end = 100;
+                        end = dots[dots.length - 1].offset || 100;
                         j = ii;
                     }
                     end = toFloat(end);


### PR DESCRIPTION
Error occurs when trying to use a gradient such as:

``` javascript
"#fff-#f00-#000:60"
```

Which implies that the gradient goes from white to black, passing red halfway
This will currently be parsed as:

```
#fff:0 - #f00:50 - #000:60
```

instead of the correct 

```
#fff:0 - #f00-30 - #000:60
```
