### PR TITLE
Allow stroke width to scale properly

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -4193,9 +4193,6 @@ window.Raphael.svg && function (R) {
                         if (o._.sx != 1 || o._.sy != 1) {
                             value /= mmax(abs(o._.sx), abs(o._.sy)) || 1;
                         }
-                        if (o.paper._vbSize) {
-                            value *= o.paper._vbSize;
-                        }
                         node.setAttribute(att, value);
                         if (attrs["stroke-dasharray"]) {
                             addDashes(o, attrs["stroke-dasharray"], params);


### PR DESCRIPTION
When a viewbox has been set and paper size changes, all elements should adapt accordingly, but those 3 lines prevent stroke width to scale properly (see [my post](http://ehouais.net/2012/04/real-vector-graphics-know-how-to-scale)). You must have a good reason to do so, but I don't know it :)
