### PR TITLE
Fix issue with clone() that causes errors in browsers where a function's...

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -397,7 +397,7 @@
     };
 
     function clone(obj) {
-        if (Object(obj) !== obj) {
+        if (Object(obj) !== obj || typeof obj === 'function' ) {
             return obj;
         }
         var res = new obj.constructor;


### PR DESCRIPTION
... prototype is an enumerable property (e.g., FF3.6).

pathClone() calls clone() on an object after .toString has been overwritten as R._path2string

clone attempts to recursively clone obj.toString (hereafter 'func') as an object, because Object(func) === func.

It then recursively attempts to clone func.prototype, which makes a call to "new obj.constructor" (aka func itself since func.prototype.constructor === func).

since _path2string contains the code "this.join", it fails when called as a constructor (Objects don't by default have a join property).

You should test this change before merging it - Though I have tested the change fixes my problem, I am not in a place to know all the ramifications of changing the clone function.
