### PR TITLE
Fixed 'this.join undefined' error that appears in Firefox 3.5

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -803,7 +803,9 @@
         return {h: H, s: S, l: L, toString: hsltoString};
     };
     R._path2string = function () {
-        return this.join(",").replace(p2s, "$1");
+        if( this.length ){
+            return this.join(",").replace(p2s, "$1");
+        }
     };
     function repush(array, item) {
         for (var i = 0, ii = array.length; i < ii; i++) if (array[i] === item) {


### PR DESCRIPTION
Added a quick check to ensure that it's an array that we're trying to call this.join on. Before this, I couldn't get anything to draw on Firefox 3.5, afterwards it seems to be working just fine.

This resolves this issue:
https://github.com/DmitryBaranovskiy/raphael/issues/559
