### PR TITLE
Fix a bug with negative sizes in Internet Explorer 6, 7, 8, and 9

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -5690,8 +5690,12 @@ window.Raphael.vml && function (R) {
         this.height = height;
         width == +width && (width += "px");
         height == +height && (height += "px");
-        cs.width = width;
-        cs.height = height;
+        if(width[0] !== '-') {
+            cs.width = width;
+        }
+        if(height[0] !== '-') {
+            cs.height = height;
+        }
         cs.clip = "rect(0 " + width + " " + height + " 0)";
         if (this._viewBox) {
             R._engine.setViewBox.apply(this, this._viewBox);

--- a/raphael.vml.js
+++ b/raphael.vml.js
@@ -848,8 +848,12 @@ window.Raphael.vml && function (R) {
         this.height = height;
         width == +width && (width += "px");
         height == +height && (height += "px");
-        cs.width = width;
-        cs.height = height;
+        if(width[0] !== '-') {
+            cs.width = width;
+        }
+        if(height[0] !== '-') {
+            cs.height = height;
+        }
         cs.clip = "rect(0 " + width + " " + height + " 0)";
         if (this._viewBox) {
             R._engine.setViewBox.apply(this, this._viewBox);


### PR DESCRIPTION
When setting the size of the canvas size in IE to a negative value, the dreaded warning sign appears in the lower left corner of the browser with the "Error on page" message. This commit checks for a negative sign on the width and height and, if one exists, does not set the width or height.
