### PR TITLE
Re-using pattern fills

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -4211,23 +4211,33 @@ window.Raphael.svg && function (R) {
                     case "fill":
                         var isURL = Str(value).match(R._ISURL);
                         if (isURL) {
-                            el = $("pattern");
-                            var ig = $("image");
-                            el.id = R.createUUID();
-                            $(el, {x: 0, y: 0, patternUnits: "userSpaceOnUse", height: 1, width: 1});
-                            $(ig, {x: 0, y: 0, "xlink:href": isURL[1]});
-                            el.appendChild(ig);
+                            var existingImages = o.paper.defs.getElementsByTagName("image");
+                            for(var i=0; i< existingImages.length; i++){
+                               if(existingImages[i].href.baseVal === isURL[1]){
+                                 el = existingImages[i].parentNode;
+                               }
+                            }
+                            if(!el){
+                                el = $("pattern");
+                                var ig = $("image");
+                                el.id = R.createUUID();
+                                $(el, {x: 0, y: 0, patternUnits: "userSpaceOnUse", height: 1, width: 1});
+                                $(ig, {x: 0, y: 0, "xlink:href": isURL[1]});
+                                el.appendChild(ig);
 
-                            (function (el) {
-                                R._preload(isURL[1], function () {
-                                    var w = this.offsetWidth,
-                                        h = this.offsetHeight;
-                                    $(el, {width: w, height: h});
-                                    $(ig, {width: w, height: h});
-                                    o.paper.safari();
-                                });
-                            })(el);
-                            o.paper.defs.appendChild(el);
+                                (function (el) {
+                                    R._preload(isURL[1], function () {
+                                        var w = this.offsetWidth,
+                                            h = this.offsetHeight;
+                                        $(el, {width: w, height: h});
+                                        $(ig, {width: w, height: h});
+                                        o.paper.safari();
+                                    });
+                                })(el);
+
+                                o.paper.defs.appendChild(el);
+                            }
+           
                             $(node, {fill: "url(#" + el.id + ")"});
                             o.pattern = el;
                             o.pattern && updatePosition(o);


### PR DESCRIPTION
While using patterns (from external images) as a fill, i.e., fill:url(img.gif) the library was always appending new pattern elements to the dom rather than re-using existing ones. This causes a noticeable flicker on some cases while there is a new http request to get the image file. 

Try http://forio.com/simulate/latinovote/map on firefox and move the sliders to see the flickering version. If you inspect the dom you can see the new patterns being attend each time the slider moves.

Try http://latinovotemap.org with the fixed version to see that there is no flicker.

Great library btw!
