### PR TITLE
isPointInside incorrectly caches the path used to calculate its value

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -3576,7 +3576,7 @@
      = (boolean) `true` if point inside the shape
     \*/
     elproto.isPointInside = function (x, y) {
-        var rp = this.realPath = this.realPath || getPath[this.type](this);
+        var rp = this.realPath = getPath[this.type](this);
         return R.isPointInsidePath(rp, x, y);
     };
     /*\


### PR DESCRIPTION
isPointInside() caches  "this.realPath" var to calculate a return. This means if you modified a shapes attributes using the .attr() method (as opposed to using a transform) this meant the real path used would be wrong.

My change forces isPointInside to always re-calculate the realPath.

Looking through the code, it actually looks like realPath is only used as a local variable in a few methods - and not as a cached "global" variable. It might be worth removing it entirely - or alternatively create a fully featured global to cache the realPath correctly (ie update it every time the shapes' properties change).
