### PR TITLE
clone() method throws exception in sandboxed Chrome

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -397,10 +397,16 @@
     };
 
     function clone(obj) {
-        if (Object(obj) !== obj) {
+        var res;
+
+        if ("function" === typeof(obj)) {
+            res = function() { obj.apply(this, arguments); };
+        } else if (Object(obj) === obj) {
+            res = new obj.constructor;
+        } else {
             return obj;
         }
-        var res = new obj.constructor;
+
         for (var key in obj) if (obj[has](key)) {
             res[key] = clone(obj[key]);
         }


### PR DESCRIPTION
clone() method causes sandboxed Google Chrome ( extension app sandbox ) to throw "Uncaught Error: Code generation from strings disallowed for this context" exception while using path() method.

Similar issue opened with [this pull request](https://github.com/DmitryBaranovskiy/raphael/pull/573), but no way to clearly clone functions provided.
