### PR TITLE
Fix for module loaders (RequireJS)

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -219,6 +219,7 @@
     eve.toString = function () {
         return "You are running Eve " + version;
     };
+    glob.eve = eve;
     (typeof module != "undefined" && module.exports) ? (module.exports = eve) : (typeof define != "undefined" ? (define("eve", [], function() { return eve; })) : (glob.eve = eve));
 })(this);
 


### PR DESCRIPTION
Line 254 "R.eve = eve;", requires that Eve be loaded in the global namespace - regardless of module loaders.

Alternatively, one could refactor Raphael to use module loader when available, but that's outside the scope of a one-line bug fix.

By the way, thanks for the fantastic library, and documentation!
