### PR TITLE
fix for fontSize going NaN

### DIFF
--- a/raphael.svg.js
+++ b/raphael.svg.js
@@ -562,6 +562,7 @@ window.Raphael.svg && function (R) {
             node = el.node,
             fontSize = node.firstChild ? toInt(R._g.doc.defaultView.getComputedStyle(node.firstChild, E).getPropertyValue("font-size"), 10) : 10;
 
+        if (isNaN(fontSize)) fontSize = toInt(a['font-size'], 10);
         if (params[has]("text")) {
             a.text = params.text;
             while (node.firstChild) {


### PR DESCRIPTION
Under chrome sometimes getComputedStyle will return "" which
then causes parseInt to produce NaN.

If this happens try to get font-size out of the elmement attribute
hash so dy attribute can be computed.
