### PR TITLE
Added line spacing to Paper.print()

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -3627,9 +3627,10 @@
         return thefont;
     };
     
-    paperproto.print = function (x, y, string, font, size, origin, letter_spacing) {
+    paperproto.print = function (x, y, string, font, size, origin, letter_spacing, line_spacing) {
         origin = origin || "middle"; // baseline|middle
         letter_spacing = mmax(mmin(letter_spacing || 0, 1), -1);
+        line_spacing = mmax(mmin(line_spacing || 1, 3), 1);
         var letters = Str(string)[split](E),
             shift = 0,
             notfirst = 0,
@@ -3648,7 +3649,7 @@
                     shift = 0;
                     curr = 0;
                     notfirst = 0;
-                    shifty += lineHeight;
+                    shifty += lineHeight * line_spacing;
                 } else {
                     var prev = notfirst && font.glyphs[letters[i - 1]] || {},
                         curr = font.glyphs[letters[i]];

--- a/reference.html
+++ b/reference.html
@@ -1277,7 +1277,7 @@ Note: there is a special case when path consist of just three commands: “M10,1
 </code></pre>
 <p>For example of path strings, check out these icons: <a href="http://raphaeljs.com/icons/" rel="external">http://raphaeljs.com/icons/</a>
 </p>
-</div><div class="Paper-print-section"><h3 id="Paper.print" class="dr-method"><i class="dr-trixie">&#160;</i>Paper.print(x, y, string, font, [size], [origin], [letter_spacing])<a href="#Paper.print" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4977 in the source" href="https://github.com/DmitryBaranovskiy/raphael/blob/master/raphael.core.js#L4977">&#x27ad;</a></h3>
+</div><div class="Paper-print-section"><h3 id="Paper.print" class="dr-method"><i class="dr-trixie">&#160;</i>Paper.print(x, y, string, font, [size], [origin], [letter_spacing], [line_spacing])<a href="#Paper.print" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 4977 in the source" href="https://github.com/DmitryBaranovskiy/raphael/blob/master/raphael.core.js#L4977">&#x27ad;</a></h3>
 <div class="extra" id="Paper.print-extra"></div></div><div class="dr-method"><p>Creates path that represent given text written using given font at given position with given size.
 Result of the method is path element that contains whole text as a separate path.
 </p>
@@ -1307,6 +1307,10 @@ Result of the method is path element that contains whole text as a separate path
 <dd class="dr-optional">optional</dd>
 <dd class="dr-type"><em class="dr-type-number">number</em></dd>
 <dd class="dr-description">number in range <code>-1..1</code>, default is <code>0</code></dd>
+<dt class="dr-param optional">line_spacing</dt>
+<dd class="dr-optional">optional</dd>
+<dd class="dr-type"><em class="dr-type-number">number</em></dd>
+<dd class="dr-description">number in range <code>1..3</code>, default is <code>1</code></dd>
 </dl>
 <p class="dr-returns"><strong class="dr-title">Returns:</strong> <em class="dr-type-object">object</em> <span class="dr-description">resulting path element, which consist of all letters</span></p>
 <p class="header">Usage


### PR DESCRIPTION
I've added code to allow line spacing in the Paper.print method.  I've arbitrarily limited to a max of three line spacing and defaulted to one line.  Also, updated reference to reflect the new optional parameter.

Best Regards,
Dan
