### PR TITLE
Fix issue with this.join - #699

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -807,7 +807,7 @@
         return {h: H, s: S, l: L, toString: hsltoString};
     };
     R._path2string = function () {
-        return this.join(",").replace(p2s, "$1");
+        return Array.prototype.join.call(this, ",").replace(p2s, "$1");
     };
     function repush(array, item) {
         for (var i = 0, ii = array.length; i < ii; i++) if (array[i] === item) {


### PR DESCRIPTION
Opera 11 on Linux and it seams that [Firefox 3.5 too](https://github.com/DmitryBaranovskiy/raphael/pull/580) throw exception this.join is not a function.

In this PR I force it to use `join` from `Array.prototype`.
