### PR TITLE
Link to new Raphael-boilerplate repo (load raphael globally, with AMD, or HTML5 boilerplate.)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,13 +6,14 @@ Visit the library website for more information: [http://raphaeljs.com](http://ra
 
 * `git clone https://github.com/DmitryBaranovskiy/raphael.git`
 * `git submodule init && git submodule update && npm install`
-(thank you [Wes Tood](https://github.com/wesleytodd))
 
 ## Dependencies
 * [uglifyjs](https://github.com/mishoo/UglifyJS)
 * [eve](https://github.com/adobe-webplatform/eve)
 
 ## Loading
+Check [Raphael-boilerplate](https://github.com/tomasAlabes/raphael-boilerplate) to see examples of loading.
+
 Raphael can be loaded in a script tag or with AMD:
 
 ```js


### PR DESCRIPTION
Helping people load raphael with AMD, global or HTML5 boilerplate.
