### PR TITLE
groupStart() and groupFinish() for SVG

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -3475,6 +3475,14 @@
     paperproto.setViewBox = function (x, y, w, h, fit) {
         return R._engine.setViewBox.call(this, x, y, w, h, fit);
     };
+    paperproto.groupStart = function () {
+      "use strict";
+      R._engine.groupStart(this);
+    };
+    paperproto.groupFinish = function () {
+      "use strict";
+      return R._engine.groupFinish(this);
+    };
     /*\
      * Paper.top
      [ property ]

--- a/raphael.svg.js
+++ b/raphael.svg.js
@@ -682,7 +682,8 @@ window.Raphael && window.Raphael.svg && function(R) {
 
     R._engine.path = function (pathString, SVG) {
         var el = $("path");
-        SVG.canvas && SVG.canvas.appendChild(el);
+        if (SVG.__group__) SVG.__group__[0].appendChild(el);
+        else SVG.canvas && SVG.canvas.appendChild(el);
         var p = new Element(el, SVG);
         p.type = "path";
         setFillAndStroke(p, {
@@ -1148,7 +1149,8 @@ window.Raphael && window.Raphael.svg && function(R) {
     };
     R._engine.circle = function (svg, x, y, r) {
         var el = $("circle");
-        svg.canvas && svg.canvas.appendChild(el);
+        if (svg.__group__) svg.__group__[0].appendChild(el);
+        else svg.canvas && svg.canvas.appendChild(el);
         var res = new Element(el, svg);
         res.attrs = {cx: x, cy: y, r: r, fill: "none", stroke: "#000"};
         res.type = "circle";
@@ -1157,7 +1159,8 @@ window.Raphael && window.Raphael.svg && function(R) {
     };
     R._engine.rect = function (svg, x, y, w, h, r) {
         var el = $("rect");
-        svg.canvas && svg.canvas.appendChild(el);
+        if (svg.__group__) svg.__group__[0].appendChild(el);
+        else svg.canvas && svg.canvas.appendChild(el);
         var res = new Element(el, svg);
         res.attrs = {x: x, y: y, width: w, height: h, r: r || 0, rx: r || 0, ry: r || 0, fill: "none", stroke: "#000"};
         res.type = "rect";
@@ -1166,7 +1169,8 @@ window.Raphael && window.Raphael.svg && function(R) {
     };
     R._engine.ellipse = function (svg, x, y, rx, ry) {
         var el = $("ellipse");
-        svg.canvas && svg.canvas.appendChild(el);
+        if (svg.__group__) svg.__group__[0].appendChild(el);
+        else svg.canvas && svg.canvas.appendChild(el);
         var res = new Element(el, svg);
         res.attrs = {cx: x, cy: y, rx: rx, ry: ry, fill: "none", stroke: "#000"};
         res.type = "ellipse";
@@ -1177,7 +1181,8 @@ window.Raphael && window.Raphael.svg && function(R) {
         var el = $("image");
         $(el, {x: x, y: y, width: w, height: h, preserveAspectRatio: "none"});
         el.setAttributeNS(xlink, "href", src);
-        svg.canvas && svg.canvas.appendChild(el);
+        if (svg.__group__) svg.__group__[0].appendChild(el);
+        else svg.canvas && svg.canvas.appendChild(el);
         var res = new Element(el, svg);
         res.attrs = {x: x, y: y, width: w, height: h, src: src};
         res.type = "image";
@@ -1185,7 +1190,8 @@ window.Raphael && window.Raphael.svg && function(R) {
     };
     R._engine.text = function (svg, x, y, text) {
         var el = $("text");
-        svg.canvas && svg.canvas.appendChild(el);
+        if (svg.__group__) svg.__group__[0].appendChild(el);
+        else svg.canvas && svg.canvas.appendChild(el);
         var res = new Element(el, svg);
         res.attrs = {
             x: x,
@@ -1285,6 +1291,21 @@ window.Raphael && window.Raphael.svg && function(R) {
         }
         this._viewBox = [x, y, w, h, !!fit];
         return this;
+    };
+    R._engine.groupStart = function (svg) {
+      "use strict";
+      var el = $("g");
+      var res = new Element(el, svg);
+      $(el, res.attrs);
+      svg.__group__ = res;
+      return res;
+    };
+    R._engine.groupFinish = function (svg) {
+      "use strict";
+      var res = svg.__group__;
+      svg.__group__ = undefined;
+      svg.canvas && svg.canvas.appendChild(res[0]);
+      return res;
     };
     /*\
      * Paper.renderfix

--- a/raphael.vml.js
+++ b/raphael.vml.js
@@ -886,6 +886,8 @@ window.Raphael && window.Raphael.vml && function(R) {
         });
         return this;
     };
+    R._engine.groupStart = function() { throw new Error("not implemented for vml"); };
+    R._engine.groupFinish = function() { throw new Error("not implemented for vml"); };
     var createNode;
     R._engine.initWin = function (win) {
             var doc = win.document;


### PR DESCRIPTION
- Added groupStart() and groupFinish() functions
- Creates SVG group element instead of Raphael Set / array
- Usage exactly like setStart() and setFinish()
- Results in better animation performance
- Not yet implemented for VML
