### PR TITLE
Line element

### DIFF
--- a/raphael.core.js
+++ b/raphael.core.js
@@ -3307,6 +3307,28 @@
         return out;
     };
     /*\
+     * Paper.Line
+     [ method ]
+     **
+     * Draws a Line.
+     **
+     > Parameters
+     **
+     - x1 (number) x coordinate of the start of the line
+     - y1 (number) y coordinate of the start of the line
+     - x2 (number) x coordinate of the end of the line
+     - y2 (number) y coordinate of the end of the line
+     = (object) Raphaël element object with type “line”
+     **
+     > Usage
+     | var l = paper.line(10, 20, 30, 40);
+     || 0\*/
+    paperproto.line = function (x1, y1, x2, y2) {
+        var out = R._engine.line(this, x1 || 0, y1 || 0, x2 || 0, y2 || 0);
+        this.__set__ && this.__set__.push(out);
+        return out;
+    };
+    /*\
      * Paper.path
      [ method ]
      **

--- a/raphael.svg.js
+++ b/raphael.svg.js
@@ -1173,6 +1173,15 @@ window.Raphael && window.Raphael.svg && function(R) {
         $(el, res.attrs);
         return res;
     };
+    R._engine.line = function (svg, x1, y1, x2, y2) {
+        var el = $("line");
+        svg.canvas && svg.canvas.appendChild(el);
+        var res = new Element(el, svg);
+        res.attrs = {x1: x1, y1: y1, x2: x2, y2: y2, fill: "none", stroke: "#000"};
+        res.type = "line";
+        $(el, res.attrs);
+        return res;
+    };
     R._engine.image = function (svg, src, x, y, w, h) {
         var el = $("image");
         $(el, {x: x, y: y, width: w, height: h, preserveAspectRatio: "none"});


### PR DESCRIPTION
Hello.

I've explore the Raphaël code and added the line element in the SVG implementation, I couldn't do it for the VML implementation. Is there a reason for Raphaël not having the Line element?

Anyway, in the implementation I committed is now possible to use

```
paper.line(10, 10, 30, 30);
```

to draw a line.
