### PR TITLE
Element.rotate takes radians, not degrees

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -554,16 +554,16 @@ If key is not provided, removes all the data of the element.
 <dd class="dr-description">animation object</dd>
 </dl>
 <p class="dr-returns"><strong class="dr-title">Returns:</strong> <em class="dr-type-object">object</em> <span class="dr-description">original element</span></p>
-</div><div class="Element-rotate-section"><h3 id="Element.rotate" class="dr-method"><i class="dr-trixie">&#160;</i>Element.rotate(deg, [cx], [cy])<a href="#Element.rotate" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 708 in the source" href="https://github.com/DmitryBaranovskiy/raphael/blob/master/raphael.svg.js#L708">&#x27ad;</a></h3>
+</div><div class="Element-rotate-section"><h3 id="Element.rotate" class="dr-method"><i class="dr-trixie">&#160;</i>Element.rotate(rad, [cx], [cy])<a href="#Element.rotate" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 708 in the source" href="https://github.com/DmitryBaranovskiy/raphael/blob/master/raphael.svg.js#L708">&#x27ad;</a></h3>
 <div class="extra" id="Element.rotate-extra"></div></div><div class="dr-method"><p>Deprecated! Use <a href="#Element.transform" class="dr-link">Element.transform</a> instead.
 Adds rotation by given angle around given point to the list of
 transformations of the element.
 </p>
 <p class="header">Parameters
 </p>
-<dl class="dr-parameters"><dt class="dr-param">deg</dt>
+<dl class="dr-parameters"><dt class="dr-param">rad</dt>
 <dd class="dr-type"><em class="dr-type-number">number</em></dd>
-<dd class="dr-description">angle in degrees</dd>
+<dd class="dr-description">angle in radians</dd>
 <dt class="dr-param optional">cx</dt>
 <dd class="dr-optional">optional</dd>
 <dd class="dr-type"><em class="dr-type-number">number</em></dd>


### PR DESCRIPTION
Even though it's deprecated, worthwhile keeping the docs updated.
