### PR TITLE
Added in "behavior:url(#default#VML)" to var cssdot.

### DIFF
--- a/raphael.vml.js
+++ b/raphael.vml.js
@@ -27,7 +27,7 @@ window.Raphael && window.Raphael.vml && function(R) {
         bites = /([clmz]),?([^clmz]*)/gi,
         blurregexp = / progid:\S+Blur\([^\)]+\)/g,
         val = /-?[^,\s-]+/g,
-        cssDot = "position:absolute;left:0;top:0;width:1px;height:1px",
+        cssDot = "position:absolute;left:0;top:0;width:1px;height:1px;behavior:url(#default#VML)",
         zoom = 21600,
         pathTypes = {path: 1, rect: 1, image: 1},
         ovalTypes = {circle: 1, ellipse: 1},


### PR DESCRIPTION
This change fixes a bug I found where if you try to render shapes/figures in IE8 standards mode they will not display.  This will allow correct rendering of shapes/figures.
