### PR TITLE
Add a bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "raphael",
+  "version": "2.1.0",
+  "main": "raphael.js",
+  "ignore": [
+    "eve",
+    "**/.*",
+    "*.html",
+    "*.json",
+    "*.markdown",
+    "*.md",
+    "copy.js",
+    "Gruntfile.js",
+    "raphael.core.js",
+    "raphael.svg.js",
+    "raphael.vml.js",
+    "reference.js"
+  ]
+}


### PR DESCRIPTION
Defined a [bower](http://bower.io/) package.

Currently installing Raphael with Bower pulls down the entire repo. With this `bower.json` you just get:
- `raphael.js`
- `raphael-min.js`
- `license.txt`
