### PR TITLE
Added clip-path attribute to elements to support non-rectangular clippin...

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -591,6 +591,7 @@
             "text-anchor": "middle",
             title: "Raphael",
             transform: "",
+            "clip-path": "",
             width: 0,
             x: 0,
             y: 0
@@ -6022,16 +6023,19 @@
         "--..": [8, 3, 1, 3, 1, 3]
     },
     addDashes = function (o, value, params) {
-        value = dasharray[Str(value).toLowerCase()];
-        if (value) {
+        var textvalue = dasharray[Str(value).toLowerCase()];
+        if (textvalue) {
             var width = o.attrs["stroke-width"] || "1",
                 butt = {round: width, square: width, butt: 0}[o.attrs["stroke-linecap"] || params["stroke-linecap"]] || 0,
                 dashes = [],
-                i = value.length;
+                i = textvalue.length;
             while (i--) {
-                dashes[i] = value[i] * width + ((i % 2) ? 1 : -1) * butt;
+                dashes[i] = textvalue[i] * width + ((i % 2) ? 1 : -1) * butt;
             }
             $(o.node, {"stroke-dasharray": dashes.join(",")});
+        }
+        else {
+            $(o.node, {"stroke-dasharray": value});
         }
     },
     setFillAndStroke = function (o, params) {
@@ -6078,6 +6082,27 @@
                     case "arrow-end":
                         addArrow(o, value, 1);
                         break;
+                    case "clip-path":
+                        if(value) {
+                            o.clip && o.clip.parentNode.parentNode.removeChild(o.clip.parentNode);
+                            var el = $("clipPath"),
+                                path = $("path");
+                            el.id = R.createUUID();
+                            $(path, {d: value});
+                            el.appendChild(path);
+                            o.paper.defs.appendChild(el);
+                            $(node, {"clip-path": "url(#" + el.id + ")"});
+                            o.clip = path;
+                        }
+                        else {
+                            var path = node.getAttribute("clip-path");
+                            if (path) {
+                                var clip = R._g.doc.getElementById(path.replace(/(^url\(#|\)$)/g, E));
+                                clip && clip.parentNode.removeChild(clip);
+                                $(node, {"clip-path": E});
+                                delete o.clip;
+                            }
+                        }
                     case "clip-rect":
                         var rect = Str(value).split(separator);
                         if (rect.length == 4) {


### PR DESCRIPTION
Two changes, sadly in one commit because I'm new to git.
- Added a clip-path attribute so that I could have a non-rectangular clip for another element.   The value of the attribute is the ID of a type=path element to use as the clip boundary.
- Changed stroke-dasharray to respect a normal stroke specification if the shorthand specifications are all exhausted.
