### PR TITLE
Allow Raphael to work in pages with a Content Security Policy that disallows 'unsafe-eval'.

### DIFF
--- a/dev/raphael.core.js
+++ b/dev/raphael.core.js
@@ -126,7 +126,7 @@
              | var c = paper.circle(10, 10, 10).attr({hue: .45});
              | // or even like this:
              | c.animate({hue: 1}, 1e3);
-             | 
+             |
              | // You could also create custom attribute
              | // with multiple parameters:
              | paper.customAttributes.hsb = function (h, s, b) {
@@ -417,7 +417,13 @@
         if (Object(obj) !== obj) {
             return obj;
         }
-        var res = new obj.constructor;
+        var res;
+        if (!obj.join) {
+          res = function(){};
+        }
+        else {
+          res = new obj.constructor;
+        }
         for (var key in obj) if (obj[has](key)) {
             res[key] = clone(obj[key]);
         }
@@ -3076,7 +3082,7 @@
      [ method ]
      **
      * Adds or retrieves given value asociated with given key.
-     ** 
+     **
      * See also @Element.removeData
      > Parameters
      - key (string) key to store data
@@ -3184,8 +3190,8 @@
      - mcontext (object) #optional context for moving handler
      - scontext (object) #optional context for drag start handler
      - econtext (object) #optional context for drag end handler
-     * Additionaly following `drag` events will be triggered: `drag.start.<id>` on start, 
-     * `drag.end.<id>` on end and `drag.move.<id>` on every move. When element will be dragged over another element 
+     * Additionaly following `drag` events will be triggered: `drag.start.<id>` on start,
+     * `drag.end.<id>` on end and `drag.move.<id>` on every move. When element will be dragged over another element
      * `drag.over.<id>` will be fired as well.
      *
      * Start event and start handler will be called in specified context or in context of the element with following parameters:
@@ -3487,7 +3493,7 @@
      * Paper.setViewBox
      [ method ]
      **
-     * Sets the view box of the paper. Practically it gives you ability to zoom and pan whole paper surface by 
+     * Sets the view box of the paper. Practically it gives you ability to zoom and pan whole paper surface by
      * specifying new boundaries.
      **
      > Parameters
@@ -3960,7 +3966,7 @@
     elproto.getPath = function () {
         var path,
             getPath = R._getPath[this.type];
-        
+
         if (this.type == "text" || this.type == "set") {
             return;
         }
@@ -4246,8 +4252,8 @@
             }
         }
         return element;
-        // 
-        // 
+        //
+        //
         // var a = params ? R.animation(params, ms, easing, callback) : anim,
         //     status = element.status(anim);
         // return this.animate(a).status(a, status * anim.ms / a.ms);


### PR DESCRIPTION
Special case the Clone method to avoid using the Function constructor so Raphael works in pages with a Content Security Policy that disallows eval.

The input to this function is really only ever a function and and array, but unfortunately `typeof` or `instanceof` checks here won't work because the arrays will pass the same checks as the functions. Since the only special operation that's performed on the arrays is a `join`, I used that to detect whether to use a constructor or to fallback to a function literal.

The rest is just my editor stripping whitespace, which is probably a good thing anyways.
