### PR TITLE
Fix bug with arrow-end/start markers sharing properties

### DIFF
--- a/dev/raphael.svg.js
+++ b/dev/raphael.svg.js
@@ -204,7 +204,7 @@ window.Raphael && window.Raphael.svg && function(R) {
             }
             if (type != "none") {
                 var pathId = "raphael-marker-" + type,
-                    markerId = "raphael-marker-" + se + type + w + h;
+                    markerId = "raphael-marker-" + se + type + w + h + "-obj" + o.id;
                 if (!R._g.doc.getElementById(pathId)) {
                     p.defs.appendChild($($("path"), {
                         "stroke-linecap": "round",


### PR DESCRIPTION
This pull request fixes the bug in arrow end/start markers sharing properties (see at least issues #471 #530 #619). This fix assigns a unique ID to every marker using the ID of the path object. Thus, for each arrow on every object, a `marker` element is created inside `defs`. There still is only one path element in `defs` for each type of marker. The removal of unused paths and markers still works as well.

I think creating one element for each arrow is an acceptable compromise and a simple fix.
