### PR TITLE
Fix for touch event listeners not properly removed

### DIFF
--- a/dev/raphael.core.js
+++ b/dev/raphael.core.js
@@ -2746,7 +2746,7 @@
                     obj.removeEventListener(type, f, false);
 
                     if (supportsTouch && touchMap[type])
-                        obj.removeEventListener(touchMap[type], f, false);
+                        obj.removeEventListener(touchMap[type], _f, false);
 
                     return true;
                 };


### PR DESCRIPTION
Fix for touch event listeners not properly removed because of a wrong function name.
