### PR TITLE
Fix for touch event listeners not properly removed

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -3125,7 +3125,7 @@
                     obj.removeEventListener(type, f, false);
 
                     if (supportsTouch && touchMap[type])
-                        obj.removeEventListener(touchMap[type], f, false);
+                        obj.removeEventListener(touchMap[type], _f, false);
 
                     return true;
                 };


### PR DESCRIPTION
Fix for touch event listeners not properly removed because of a wrong function name.
