### PR TITLE
setting aspect ratio to "xMidYMid meet".  Fixes #649

### DIFF
--- a/dev/raphael.svg.js
+++ b/dev/raphael.svg.js
@@ -1264,7 +1264,7 @@ window.Raphael && window.Raphael.svg && function(R) {
         eve("raphael.setViewBox", this, this._viewBox, [x, y, w, h, fit]);
         var size = mmax(w / this.width, h / this.height),
             top = this.top,
-            aspectRatio = fit ? "meet" : "xMinYMin",
+            aspectRatio = fit ? "xMidYMid meet" : "xMinYMin",
             vb,
             sw;
         if (x == null) {


### PR DESCRIPTION
"meet" is not a valid SVG value for preserveAspectRatio.  The correct value should be "xMidYMid meet".
