### PR TITLE
add support for percentage width and height styles

### DIFF
--- a/dev/raphael.vml.js
+++ b/dev/raphael.vml.js
@@ -853,6 +853,8 @@ window.Raphael && window.Raphael.vml && function(R) {
         height == +height && (height += "px");
         cs.width = width;
         cs.height = height;
+        if((width + '').match(/%$/)) width = this.canvas.offsetWidth + 'px';
+        if((height + '').match(/%$/)) height = this.canvas.offsetHeight + 'px';
         cs.clip = "rect(0 " + width + " " + height + " 0)";
         if (this._viewBox) {
             R._engine.setViewBox.apply(this, this._viewBox);


### PR DESCRIPTION
Problem:  <svg> elements styled with percentage widths or heights (e.g. `width: 100%`) throw an error on the line `cs.clip = "rect(0 " + width + " " + height + " 0)";`

Proposed solution:  apply to the canvas whatever width/height are provided, then if width/height are percentage strings, read the computed (pixel) width/height using offsetWidth and offsetHeight, passing those values to the cs.clip property.

Not extensively tested, but fixed the bugs I was coming up against.  Hopefully someone with more knowledge of this project can review and see if this is a suitable fix.
