### PR TITLE
Bug fix: Incorrect position when multiple pause/resume

### DIFF
--- a/dev/raphael.core.js
+++ b/dev/raphael.core.js
@@ -4686,7 +4686,7 @@
             len,
             e;
         if (value != null) {
-            runAnimation(anim, this, -1, mmin(value, 1));
+            runAnimation(anim, this, 100, mmin(value, 1));
             return this;
         } else {
             len = animationElements.length;


### PR DESCRIPTION
This bug can be reproduced at http://jsfiddle.net/sf3ve/
When an animations pause and resume multiple times, the position is incorrect.
