### PR TITLE
Bug fix: incorrect font selected

### DIFF
--- a/dev/raphael.core.js
+++ b/dev/raphael.core.js
@@ -5128,10 +5128,12 @@
             }
         }
         var thefont;
+        vat thefontstyle;
         if (font) {
             for (var i = 0, ii = font.length; i < ii; i++) {
                 thefont = font[i];
-                if (thefont.face["font-weight"] == weight && (thefont.face["font-style"] == style || !thefont.face["font-style"]) && thefont.face["font-stretch"] == stretch) {
+                thefontstyle = thefont.face["font-style"] || "normal";
+                if (thefont.face["font-weight"] == weight && thefontstyle == style && thefont.face["font-stretch"] == stretch) {
                     break;
                 }
             }


### PR DESCRIPTION
Style is ignored when there is no font-style in registered font. 
This bug can be reproduced at http://jsfiddle.net/tasior/z13Lgk1a/
Following condition is wrong:
(thefont.face["font-style"] == style || !thefont.face["font-style"])
When you register font without "font-style" and then another in same family and same weight it will pick the first one always.