### PR TITLE
Correct input for `Raphael.deg()`.

### DIFF
--- a/reference.html
+++ b/reference.html
@@ -1646,7 +1646,7 @@ Return bounding box of a given cubic bezier curve
 </div><div class="Raphael-createUUID-section"><h3 id="Raphael.createUUID" class="dr-method"><i class="dr-trixie">&#160;</i>Raphael.createUUID()<a href="#Raphael.createUUID" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 497 in the source" href="https://github.com/DmitryBaranovskiy/raphael/blob/master/raphael.core.js#L497">&#x27ad;</a></h3>
 <div class="extra" id="Raphael.createUUID-extra"></div></div><div class="dr-method"><p>Returns RFC4122, version 4 ID
 </p>
-</div><div class="Raphael-deg-section"><h3 id="Raphael.deg" class="dr-method"><i class="dr-trixie">&#160;</i>Raphael.deg(deg)<a href="#Raphael.deg" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 457 in the source" href="https://github.com/DmitryBaranovskiy/raphael/blob/master/raphael.core.js#L457">&#x27ad;</a></h3>
+</div><div class="Raphael-deg-section"><h3 id="Raphael.deg" class="dr-method"><i class="dr-trixie">&#160;</i>Raphael.deg(rad)<a href="#Raphael.deg" title="Link to this section" class="dr-hash">&#x2693;</a><a class="dr-sourceline" title="Go to line 457 in the source" href="https://github.com/DmitryBaranovskiy/raphael/blob/master/raphael.core.js#L457">&#x27ad;</a></h3>
 <div class="extra" id="Raphael.deg-extra"></div></div><div class="dr-method"><p>Transform angle to degrees
 </p>
 <p class="header">Parameters


### PR DESCRIPTION
Function accepts radians not degrees.