### PR TITLE
Use HTTPS to fetch the eve submodule, not the git protocol.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "eve"]
 	path = eve
-	url = git://github.com/adobe-webplatform/eve.git
+	url = https://github.com/adobe-webplatform/eve.git


### PR DESCRIPTION
This improves the clonability of the raphael repository from inside
large organizations.

"[The Git protocol] requires firewall access to port 9418, which isn't
a standard port that corporate firewalls always allow. Behind big
corporate firewalls, this obscure port is commonly blocked." -
<http://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols>