### PR TITLE
fix where the gradient fill would not find the defining element, when url contains anchor (#) information

### DIFF
--- a/dev/raphael.svg.js
+++ b/dev/raphael.svg.js
@@ -127,7 +127,7 @@ window.Raphael && window.Raphael.svg && function(R) {
             }
         }
         $(o, {
-            fill: "url('" + document.location + "#" + id + "')",
+            fill: "url('" + document.location.pathname + "#" + id + "')",
             opacity: 1,
             "fill-opacity": 1
         });


### PR DESCRIPTION
the gradient fill wouldn't find its defining elements from the svg defs section, because it is referred to in an absolute manner, and the url would include anchor (#) tags.

the url has been replaced with "document.location.pathname", which is the relative reference, and seems to be working.

I am not sure of the implications of this modifications, but the fix worked beautifully for me.