### PR TITLE
Use HTTPS to fetch eve, not the git protocol

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "2.1.4",
   "main": "raphael.js",
   "dependencies": {
-    "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+    "eve": "https://github.com/adobe-webplatform/eve.git#eef80ed"
   },
   "ignore": [
     "eve",


### PR DESCRIPTION
This should improve the installability of raphael from inside large
organizations.

"[The Git protocol] requires firewall access to port 9418, which isn't
a standard port that corporate firewalls always allow. Behind big
corporate firewalls, this obscure port is commonly blocked." -
https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols

This is analogous to #928.
