### PR TITLE
fixed rounding issue in RGB formatter

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -1381,7 +1381,8 @@
      = (string) hex representation of the colour.
     \*/
     R.rgb = cacher(function (r, g, b) {
-        return "#" + (16777216 | b | (g << 8) | (r << 16)).toString(16).slice(1);
+        function round(x) { return (x + 0.5) | 0; }
+        return "#" + (16777216 | round(b) | (round(g) << 8) | (round(r) << 16)).toString(16).slice(1);
     });
     /*\
      * Raphael.getColor


### PR DESCRIPTION
RGB formatter should round the r, g, b components instead of truncating them. This causes a roundtrip problem. For example #aabbcc -> rgb -> hsv -> rgb -> #aabacc. It causes weird behavior in the [colorwheel](https://github.com/jweir/colorwheel) jQuery plugin.