### PR TITLE
set stop-opacity in gradient defs

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -2502,6 +2502,7 @@
                 if (dot.color.error) {
                     return null;
                 }
+                dot.opacity = dot.color.opacity;
                 dot.color = dot.color.hex;
                 par[2] && (dot.offset = par[2] + "%");
                 dots.push(dot);
@@ -5915,7 +5916,8 @@
                 for (var i = 0, ii = dots.length; i < ii; i++) {
                     el.appendChild($("stop", {
                         offset: dots[i].offset ? dots[i].offset : i ? "100%" : "0%",
-                        "stop-color": dots[i].color || "#fff"
+                        "stop-color": dots[i].color || "#fff",
+                        "stop-opacity": isFinite(dots[i].opacity) ? dots[i].opacity : 1,
                     }));
                 }
             }


### PR DESCRIPTION
If a gradient is specified with rgba values, the stop elements of the gradient definitions should have their `stop-opacity` attribute set to the opacity of the rgba value.

This fix makes it possible to define gradients that progressively change both the color and the opacity.