### PR TITLE
Reduce transform string to avoid long parsing times

### DIFF
--- a/dev/raphael.svg.js
+++ b/dev/raphael.svg.js
@@ -869,6 +869,9 @@
             this.attr({"stroke-width": sw});
         }
 
+        //Reduce transform string
+        _.transform = this.matrix.toTransformString();
+
         return this;
     };
     /*\


### PR DESCRIPTION
Reduce transform string to avoid long parsing times after several transformations