### PR TITLE
Bug: getFont() returns wrong font-style version of font

### DIFF
--- a/dev/raphael.core.js
+++ b/dev/raphael.core.js
@@ -5168,11 +5168,11 @@
         var thefont;
         if (font) {
             for (var i = 0, ii = font.length; i < ii; i++) {
-                thefont = font[i];
-                if (thefont.face["font-weight"] == weight && (thefont.face["font-style"] == style || !thefont.face["font-style"]) && thefont.face["font-stretch"] == stretch) {
-                    break;
+                if (font[i].face["font-weight"] == weight && (font[i].face["font-style"] == style || !font[i].face["font-style"] && style=="normal") && font[i].face["font-stretch"] == stretch) {
+                    thefont = font[i];
                 }
             }
+            if (!thefont) thefont = font[0];
         }
         return thefont;
     };


### PR DESCRIPTION
The `getFont()` method doesn't return correct version of given font family based on `font-style` attribute. See example here: https://jsfiddle.net/slonichobot/spbhmc2n/1/ (shortened font generated by [cufon](http://cufon.shoqolate.com/generate/)).
- the second letter '**A**' should be *italic*.