### PR TITLE
Add meta content in HTML page

### DIFF
--- a/dev/raphaelTest.html
+++ b/dev/raphaelTest.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
 <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <title>Raphael Dev testing html</title>
 
     <!-- HTML to try new developments in Raphael -->


### PR DESCRIPTION
Add the meta content in the HTML page to prevent "The character encoding of the HTML document was not declared" which might be caused in some browsers.