### PR TITLE
global variable define fix

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -8261,8 +8261,9 @@
 (function (glob, factory) {
     if (typeof define === "function" && define.amd) {
         define("raphael", ["raphael.core", "raphael.svg", "raphael.vml"], function(Raphael) {
-            return (glob.Raphael = factory(Raphael));
+            return factory(Raphael);
         });
+        glob.Raphael = require("raphael");
     } else if (typeof exports === "object") {
         var raphael = require("raphael.core");
 


### PR DESCRIPTION
There's no way to declare global variable without requesting `require("raphael")`, but there are possible cases when we have the `define.amd`, and we need to get the global variable without using amd.