### PR TITLE
Remove transform string reduction to prevent incorrect animations.

### DIFF
--- a/dev/raphael.svg.js
+++ b/dev/raphael.svg.js
@@ -875,9 +875,6 @@ define(["./raphael.core"], function(R) {
             this.attr({"stroke-width": sw});
         }
 
-        //Reduce transform string
-        _.transform = this.matrix.toTransformString();
-
         return this;
     };
     /*\


### PR DESCRIPTION
This reverses f82a25f89b42749f2f91d8eb01bae8e79ff0a2bb and closes #1059.

It may be possible to restore the optimization from that commit for .attr() [where it should be correct] but not .animate(), but that's beyond my skill in this codebase.