### PR TITLE
Update GitHub URL for eve

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     }
   ],
   "dependencies": {
-    "eve": "git://github.com/adobe-webplatform/eve.git#eef80ed"
+    "eve": "https://github.com/adobe-webplatform/eve.git#eef80ed"
   },
   "devDependencies": {
     "bower": "1.4.1",


### PR DESCRIPTION
The old `git://` URL didn't work anymore.
