### PR TITLE
Check that <tspan> computed styles are valid or fallback to default

### DIFF
--- a/dev/raphael.svg.js
+++ b/dev/raphael.svg.js
@@ -582,7 +582,8 @@ define(["./raphael.core"], function(R) {
         }
         var a = el.attrs,
             node = el.node,
-            fontSize = node.firstChild ? toInt(R._g.doc.defaultView.getComputedStyle(node.firstChild, E).getPropertyValue("font-size"), 10) : 10;
+            computedFontSize = node.firstChild && toInt(R._g.doc.defaultView.getComputedStyle(node.firstChild, E).getPropertyValue("font-size"), 10),
+            fontSize = isNaN(computedFontSize) ? 10 : computedFontSize;
 
         if (params[has]("text")) {
             a.text = params.text;


### PR DESCRIPTION
**What does this PR do?**
This PR resolves an edge case I've stumbled across while rendering pages in `phantomjs` where computed styles for a `<tspan>` element can end up in a situation where all property values are set as empty strings.

This results in the `fontSize` value below being `NaN`. The fix in place will ensure that `NaN` values at this point also fallback to the default font size of `10`.

Notably, if `node.firstChild` doesn't not exist, `fontSize` should still fallback to the default as: `isNaN(undefined) // true`

**What is the root cause here?**
I think that the issue I've observed might be related to something like this https://bugs.webkit.org/show_bug.cgi?id=14563 but am not 100% sure. 

**Who might be interested in this PR?**
@tomasAlabes
