### PR TITLE
Fix memory leak in `Element.removeData()`

### DIFF
--- a/dev/raphael.core.js
+++ b/dev/raphael.core.js
@@ -3120,7 +3120,7 @@ define(["eve"], function(eve) {
     \*/
     elproto.removeData = function (key) {
         if (key == null) {
-            eldata[this.id] = {};
+            delete eldata[this.id];
         } else {
             eldata[this.id] && delete eldata[this.id][key];
         }


### PR DESCRIPTION
Prior to this change, `Element.removeData()` replaces an element's data with an empty object. This behavior results in a slow memory leak for applications that do not re-use IDs, as Raphael continues to add new keys and objects to `eldata` over time.

This memory leak turns out to be a problem for [Piwik](https://piwik.org/), which uses
kartographer.js (which uses raphael) to draw an SVG image of the United States
in its dashboard ([see demo](https://demo.piwik.org/index.php?module=CoreHome&action=index&idSite=3&period=day&date=yesterday)).

Every time the dashboard is redrawn, it spawns ~700 new Elements with data. [I've submitted a pull request that appropriately cleans up this data when the user navigates away from the page using `removeData`](https://github.com/piwik/piwik/pull/11350), but Raphael leaves an empty object in the `eldata` map keyed on the element's old ID. Since kartographer/Piwik does not reuse IDs, `eldata` grows continually on each redraw until the application is out of memory.