### PR TITLE
in IE8 it is undefined, not null fix #951,#1037

### DIFF
--- a/dev/raphael.vml.js
+++ b/dev/raphael.vml.js
@@ -490,7 +490,7 @@ define(["./raphael.core"], function(R) {
             skew.matrix = Str(matrix);
             skew.offset = matrix.offset();
         }
-        if (oldt !== null) { // empty string value is true as well
+        if (oldt != null) { // empty string value is true as well; oldt maybe undefined, use `!= null` instead
             this._.transform = oldt;
             R._extractTransform(this, oldt);
         }


### PR DESCRIPTION
Call transform may crash in old browsers IE = 8.

