### PR TITLE
upgrade webpack to v3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
     "bower": "1.8.0",
     "eslint": "3.10.0",
     "eslint-config-standard": "6.2.1",
-    "eslint-loader": "1.6.1",
+    "eslint-loader": "^1.9.0",
     "eslint-plugin-promise": "3.3.2",
     "eslint-plugin-standard": "2.0.1",
     "qunitjs": "2.0.1",
-    "webpack": "1.13.3"
+    "webpack": "^3.10.0"
   },
   "scripts": {
     "start": "npm install && bower install",
-    "build": "webpack && webpack --min && webpack --no-deps && webpack --no-deps --min",
+    "build": "webpack && webpack --min && webpack --env.noDeps && webpack --env.noDeps --env.min",
     "test": "echo \"Open dev/test/index.html with your browser\" && exit 1"
   },
   "repository": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,63 +2,68 @@
 
 const webpack = require("webpack");
 const fs = require("fs");
+const path = require("path");
 
-const args = process.argv;
-
-let plugins = [
-	new webpack.BannerPlugin(fs.readFileSync('./dev/banner.txt', 'utf8'), { raw: true, entryOnly: true })
-];
-let externals = [];
-let filename = "raphael";
-
-
-if(args.indexOf('--no-deps') !== -1){
-	console.log('Building version without deps');
-	externals.push("eve");
-	filename += ".no-deps"
-}
-
-if(args.indexOf('--min') !== -1){
-	console.log('Building minified version');
-	plugins.push(
-		new webpack.optimize.UglifyJsPlugin({
-			compress:{
-				dead_code: false,
-				unused: false
-			}
+module.exports = function(env) {
+	let plugins = [
+		new webpack.BannerPlugin({
+			banner: fs.readFileSync('./dev/banner.txt', 'utf8'),
+			raw: true,
+			entryOnly: true
 		})
-	);
-	filename += ".min"
-}
+	];
+	let externals = [];
+	let filename = "raphael";
 
-module.exports = {
-	entry: './dev/raphael.amd.js',
-	output: {
-		filename: filename + ".js",
-		libraryTarget: "umd",
-		library: "Raphael"
-	},
-
-	externals: externals,
-
-	plugins: plugins,
-
-	loaders: [
-  		{
-  			test: /\.js$/, 
-  			loader: "eslint-loader", 
-  			include: "./dev/"
-  		}
-	],
-  	
-	eslint: {
-    	configFile: './.eslintrc'
-  	},
-
-	resolve: {
-		modulesDirectories: ["bower_components"],
-		alias: {
-			"eve": "eve-raphael/eve"
-		}
+	if(env && env.noDeps){
+		console.log('Building version without deps');
+		externals.push("eve");
+		filename += ".no-deps"
 	}
+
+	if(env && env.min){
+		console.log('Building minified version');
+		plugins.push(
+			new webpack.optimize.UglifyJsPlugin({
+				compress:{
+					dead_code: false,
+					unused: false
+				}
+			})
+		);
+		filename += ".min"
+	}
+
+	return {
+		entry: './dev/raphael.amd.js',
+		output: {
+			filename: filename + ".js",
+			libraryTarget: "umd",
+			library: "Raphael"
+		},
+
+		externals: externals,
+
+		plugins: plugins,
+
+		module: {
+			rules: [
+				{
+					test: /\.js$/,
+					loader: "eslint-loader",
+					include: path.join(__dirname, "dev"),
+					options: {
+						configFile: path.join(__dirname, '.eslintrc.js')
+					}
+				}
+			],
+		},
+
+		resolve: {
+			modules: ["bower_components", "node_modules"],
+			alias: {
+				"eve": "eve-raphael/eve"
+			}
+		}
+	};
 };


### PR DESCRIPTION
known issue: es-lint validation is broken.
If I'm correct, es-lint config was not configured properly for older builds. Let me know how to handle es-list issues.