### PR TITLE
Fix drag offsets passed to "drag.start" from touch drags in elproto.drag

### DIFF
--- a/dev/raphael.core.js
+++ b/dev/raphael.core.js
@@ -3222,7 +3222,7 @@ define(["eve"], function(eve) {
             onstart && eve.on("raphael.drag.start." + this.id, onstart);
             onmove && eve.on("raphael.drag.move." + this.id, onmove);
             onend && eve.on("raphael.drag.end." + this.id, onend);
-            eve("raphael.drag.start." + this.id, start_scope || move_scope || this, e.clientX + scrollX, e.clientY + scrollY, e);
+            eve("raphael.drag.start." + this.id, start_scope || move_scope || this, this._drag.x, this._drag.y, e);
         }
         this._drag = {};
         draggable.push({el: this, start: start});


### PR DESCRIPTION
Fixes a bug in which incorrect offsets were passed with touch drags. In `elproto.drag`, `x` and `y` are initialized to `e.clientX` and `e.clientY` respectively, but then there is code to update those values for touch events. Ultimately, the updated `x` and `y` values are added to `scrollX/scrollY` and then stored in `this._drag.x/this._drag.y`. The values passed along to `eve("raphael.drag.start.", ...)` were `e.clientX + scrollX/e.clientY + scrollY` which are the initial pre-corrected values. With this PR, the corrected values `this._drag.x/this._drag.y` are passed instead, which fixes the behavior for touch drags.

We ran into this in our application [CODAP](https://github.com/concord-consortium/codap) where we fixed it in our local embedded copy of Raphael in [CODAP PR #223](https://github.com/concord-consortium/codap/pull/223).