### PR TITLE
docs: Fix simple typo, horisontal -> horizontal

### DIFF
--- a/dev/raphael.svg.js
+++ b/dev/raphael.svg.js
@@ -770,7 +770,7 @@ define(["./raphael.core"], function(R) {
      * Adds scale by given amount relative to given point to the list of
      * transformations of the element.
      > Parameters
-     - sx (number) horisontal scale amount
+     - sx (number) horizontal scale amount
      - sy (number) vertical scale amount
      - cx (number) #optional x coordinate of the centre of scale
      - cy (number) #optional y coordinate of the centre of scale
@@ -805,7 +805,7 @@ define(["./raphael.core"], function(R) {
      * Deprecated! Use @Element.transform instead.
      * Adds translation by given amount to the list of transformations of the element.
      > Parameters
-     - dx (number) horisontal shift
+     - dx (number) horizontal shift
      - dy (number) vertical shift
      = (object) @Element
     \*/
@@ -1002,7 +1002,7 @@ define(["./raphael.core"], function(R) {
      o opacity (number)
      o path (string) SVG path string format
      o r (number) radius of the circle, ellipse or rounded corner on the rect
-     o rx (number) horisontal radius of the ellipse
+     o rx (number) horizontal radius of the ellipse
      o ry (number) vertical radius of the ellipse
      o src (string) image URL, only works for @Element.image element
      o stroke (string) stroke colour

--- a/raphael.js
+++ b/raphael.js
@@ -6328,7 +6328,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
      * Adds scale by given amount relative to given point to the list of
      * transformations of the element.
      > Parameters
-     - sx (number) horisontal scale amount
+     - sx (number) horizontal scale amount
      - sy (number) vertical scale amount
      - cx (number) #optional x coordinate of the centre of scale
      - cy (number) #optional y coordinate of the centre of scale
@@ -6363,7 +6363,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
      * Deprecated! Use @Element.transform instead.
      * Adds translation by given amount to the list of transformations of the element.
      > Parameters
-     - dx (number) horisontal shift
+     - dx (number) horizontal shift
      - dy (number) vertical shift
      = (object) @Element
     \*/
@@ -6560,7 +6560,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
      o opacity (number)
      o path (string) SVG path string format
      o r (number) radius of the circle, ellipse or rounded corner on the rect
-     o rx (number) horisontal radius of the ellipse
+     o rx (number) horizontal radius of the ellipse
      o ry (number) vertical radius of the ellipse
      o src (string) image URL, only works for @Element.image element
      o stroke (string) stroke colour

--- a/raphael.no-deps.js
+++ b/raphael.no-deps.js
@@ -6328,7 +6328,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
      * Adds scale by given amount relative to given point to the list of
      * transformations of the element.
      > Parameters
-     - sx (number) horisontal scale amount
+     - sx (number) horizontal scale amount
      - sy (number) vertical scale amount
      - cx (number) #optional x coordinate of the centre of scale
      - cy (number) #optional y coordinate of the centre of scale
@@ -6363,7 +6363,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
      * Deprecated! Use @Element.transform instead.
      * Adds translation by given amount to the list of transformations of the element.
      > Parameters
-     - dx (number) horisontal shift
+     - dx (number) horizontal shift
      - dy (number) vertical shift
      = (object) @Element
     \*/
@@ -6560,7 +6560,7 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
      o opacity (number)
      o path (string) SVG path string format
      o r (number) radius of the circle, ellipse or rounded corner on the rect
-     o rx (number) horisontal radius of the ellipse
+     o rx (number) horizontal radius of the ellipse
      o ry (number) vertical radius of the ellipse
      o src (string) image URL, only works for @Element.image element
      o stroke (string) stroke colour


### PR DESCRIPTION
There is a small typo in dev/raphael.svg.js, raphael.js, raphael.no-deps.js.

Should read `horizontal` rather than `horisontal`.

