### PR TITLE
Remove clipPath Element in defs

### DIFF
--- a/raphael.js
+++ b/raphael.js
@@ -6473,7 +6473,10 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
         eve.unbind("raphael.*.*." + this.id);
         if (this.gradient) {
             paper.defs.removeChild(this.gradient);
-        }
+		}
+		if (this.clip) {
+			paper.defs.removeChild(this.clip.parentElement);
+		}
         R._tear(this, paper);
 
         node.parentNode.removeChild(node);

--- a/raphael.js
+++ b/raphael.js
@@ -6473,10 +6473,10 @@ var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;!(__WEBPACK_AMD_
         eve.unbind("raphael.*.*." + this.id);
         if (this.gradient) {
             paper.defs.removeChild(this.gradient);
-		}
-		if (this.clip) {
-			paper.defs.removeChild(this.clip.parentElement);
-		}
+        }
+        if (this.clip) {
+            paper.defs.removeChild(this.clip.parentElement);
+        }
         R._tear(this, paper);
 
         node.parentNode.removeChild(node);


### PR DESCRIPTION
When an element is removed, the clipPath of the element should be also removed.
Otherwise the clippath of the element remains persistent.