### PR TITLE
Remove clipPath Element in defs

### DIFF
--- a/dev/raphael.svg.js
+++ b/dev/raphael.svg.js
@@ -917,7 +917,7 @@ define(["./raphael.core"], function(R) {
             paper.defs.removeChild(this.gradient);
         }
         if (this.clip) {
-            paper.defs.removeChild(this.clip.parentElement);
+            paper.defs.removeChild(this.clip.parentNode);
         }
         R._tear(this, paper);
 

--- a/dev/raphael.svg.js
+++ b/dev/raphael.svg.js
@@ -916,6 +916,9 @@ define(["./raphael.core"], function(R) {
         if (this.gradient) {
             paper.defs.removeChild(this.gradient);
         }
+        if (this.clip) {
+            paper.defs.removeChild(this.clip.parentElement);
+        }
         R._tear(this, paper);
 
         node.parentNode.removeChild(node);


### PR DESCRIPTION
When an element is removed, the clipPath of the element should be also removed.
Otherwise the clippath of the element remains persistent.