### PR TITLE
Added other supported CSS properties on RGB convert function.

### DIFF
--- a/dev/raphael.core.js
+++ b/dev/raphael.core.js
@@ -877,9 +877,15 @@ define(["eve"], function(eve) {
         if (!colour || !!((colour = Str(colour)).indexOf("-") + 1)) {
             return {r: -1, g: -1, b: -1, hex: "none", error: 1, toString: clrToString};
         }
-        if (colour == "none") {
-            return {r: -1, g: -1, b: -1, hex: "none", toString: clrToString};
-        }
+        switch (colour) {
+            case "none":
+            case "transparent":
+            case "inherit":
+            case "initial":
+            case "unset":
+            case "revert:":
+            case "revert-layer":
+                return {r: -1, g: -1, b: -1, hex: "none", toString: clrToString};
         !(hsrg[has](colour.toLowerCase().substring(0, 2)) || colour.charAt() == "#") && (colour = toHex(colour));
         var res,
             red,

--- a/dev/raphael.core.js
+++ b/dev/raphael.core.js
@@ -883,7 +883,7 @@ define(["eve"], function(eve) {
             case "inherit":
             case "initial":
             case "unset":
-            case "revert:":
+            case "revert":
             case "revert-layer":
                 return {r: -1, g: -1, b: -1, hex: "none", toString: clrToString};
         !(hsrg[has](colour.toLowerCase().substring(0, 2)) || colour.charAt() == "#") && (colour = toHex(colour));


### PR DESCRIPTION
I've noticed that some of the CSS properties are not supported at this scope. 

One of the use cases I needed was that I had a `g` element, and I need to have the possibility for the texts to have their stroke/fill inherited, unfortunately with the current state, that's not possible. 

**DISCLAIMER: I couldn't run tests, feel free to make any change whatsoever.**